### PR TITLE
2 Updates about CLib::IsValidMobile and CLib::GetClientIP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
 	},
 	"require":
 	{
-		"php" : ">=5.3.0"
+		"php" : ">=5.3.0",
+		"dekuan/vdata" : ">=1.0"
 	},
 	"require-dev" :
 	{

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false">
+    <testsuites>
+        <testsuite name="DeLib Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/CLib.php
+++ b/src/CLib.php
@@ -273,35 +273,14 @@ class CLib
 		$sRet		= '';
 		$sClientIp	= '';
 
-		//	...
-		if ( $bPlayWithProxy )
-		{
-			//
-			//	a new field defined by dekuan.org
-			//	almost like HTTP_X_FORWARDED_FOR
-			//
-			$sClientIp = self::GetEnvVar( 'HTTP_VDATA_FORWARDED_FOR', $_SERVER );
-		}
+		//
+		//	real client IP address given by HTTPD
+		//
+		$sClientIp	= self::GetEnvVar( 'REMOTE_ADDR', $_SERVER );
 
 		if ( ! self::IsExistingString( $sClientIp ) )
 		{
-			//
-			//	for acfun.cn only
-			//
-			$sClientIp = self::GetEnvVar( 'HTTP_X_TRUE_IP', $_SERVER );
-		}
-
-		if ( ! self::IsExistingString( $sClientIp ) )
-		{
-			//
-			//	It's real client IP address given by HTTPD
-			//
-			$sClientIp = self::GetEnvVar( 'REMOTE_ADDR', $_SERVER );
-		}
-
-		if ( $bPlayWithProxy )
-		{
-			if ( ! self::IsExistingString( $sClientIp ) )
+			if ( $bPlayWithProxy )
 			{
 				$sClientIp = self::GetEnvVar( 'HTTP_X_FORWARDED_FOR', $_SERVER );
 			}

--- a/src/CLib.php
+++ b/src/CLib.php
@@ -474,7 +474,7 @@ class CLib
 			return false;
 		}
 
-		$sReExp	= '/^(?:13|14|15|18|17)[0-9]{9}$/';
+		$sReExp	= '/^(?:13|14|15|16|17|18|19)[0-9]{9}$/';
 		$sStr	= ( $bTrim ? trim( $sStr ) : $sStr );
 
 		return ( 1 == preg_match( $sReExp, $sStr ) );

--- a/tests/CAssertResult.php
+++ b/tests/CAssertResult.php
@@ -24,18 +24,21 @@ class CAssertResult
 			printf( "\r\n" );
 			printf( "# ERROR %8d, ", $nErrorId );
 			printf( "%s::%s->%s\r\n", $sClassName, $sFuncName, $sCallMethod );
-			printf( "\r\n" );
-		}
-		
-		if ( null !== $vDumpString )
-		{
-			if ( is_array( $vDumpString ) )
+
+			if ( null !== $vDumpString )
 			{
-				print_r( $vDumpString );
-			}
-			else
-			{
-				var_dump( $vDumpString );	
+				if ( is_array( $vDumpString ) )
+				{
+					print_r( $vDumpString );
+				}
+				else if ( is_string( $vDumpString ) )
+				{
+					echo $vDumpString;
+				}
+				else
+				{
+					var_dump( $vDumpString );
+				}
 			}
 		}
 	}

--- a/tests/CAssertResult.php
+++ b/tests/CAssertResult.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace dekuan\delib;
+
+use dekuan\vdata\CConst;
+
+
+
+/**
+ *	Created by PhpStorm.
+ *	User: xing
+ *	Date: 5:16 PM December 15, 2017
+ */
+class CAssertResult
+{
+	public function __construct( $sClassName, $sFuncName, $sCallMethod, $nErrorId, $vDumpString = null )
+	{
+		if ( CConst::ERROR_SUCCESS === $nErrorId )
+		{
+			$this->assertTrue( true );
+		}
+		else
+		{
+			printf( "\r\n" );
+			printf( "# ERROR %8d, ", $nErrorId );
+			printf( "%s::%s->%s\r\n", $sClassName, $sFuncName, $sCallMethod );
+			printf( "\r\n" );
+		}
+		
+		if ( null !== $vDumpString )
+		{
+			if ( is_array( $vDumpString ) )
+			{
+				print_r( $vDumpString );
+			}
+			else
+			{
+				var_dump( $vDumpString );	
+			}
+		}
+	}
+	
+	public function __destruct()
+	{
+	}
+
+	public function assertTrue( $condition, $message = '' )
+	{
+		\PHPUnit\Framework\TestCase::assertTrue( $condition, $message = '' );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,12 @@
+<?php
+
+error_reporting(E_ALL | E_STRICT);
+
+//	include the composer autoloader
+$loader = require __DIR__ . '/../vendor/autoload.php';
+
+//	autoload abstract TestCase classes in test directory
+$loader->addPsr4( 'dekuan\\delib\\', __DIR__ );
+$loader->addPsr4( 'dekuan\\delib\\', __DIR__ . '/../src/' );
+$loader->addPsr4( 'dekuan\\vdata\\', __DIR__ . '/../vendor/dekuan/vdata/src/' );
+

--- a/tests/testCLib.php
+++ b/tests/testCLib.php
@@ -1,18 +1,15 @@
 <?php
 
-require_once dirname( __DIR__ ) . '/src/CEnv.php';
-require_once dirname( __DIR__ ) . '/src/CLib.php';
-
-use dekuan\delib;
+namespace dekuan\delib;
+use dekuan\vdata\CConst;
 
 
 /**
- * Created by PhpStorm.
- * User: xing
- * Date: 17/02/2017
- * Time: 12:49 AM
+ *	Created by PhpStorm.
+ *	User: xing
+ *	Date: 12:49 AM, February 17, 2017
  */
-class test extends PHPUnit_Framework_TestCase
+class testCLib extends \PHPUnit\Framework\TestCase
 {
 	public function testGetClientIP()
 	{
@@ -57,10 +54,14 @@ class test extends PHPUnit_Framework_TestCase
 
 			echo "  PARAM:  MustBePublic=" . ( $bMustBePublic ? "true" : "false" ) . ", ";
 			echo "PlayWithProxy=" . ( $bPlayWithProxy ? "true" : "false" ) . "\r\n";
-			$sClientIP	= delib\CLib::GetClientIP( $bMustBePublic, $bPlayWithProxy );
+			$sClientIP	= CLib::GetClientIP( $bMustBePublic, $bPlayWithProxy );
 			echo "  GOT IP: \"" . $sClientIP . "\"\r\n  EXPECT: \"" . $sExpect . "\"\r\n";
 
-			$this->assertTrue( 0 == strcasecmp( $sExpect, $sClientIP ) );
+			//	...
+			new CAssertResult
+			(
+				__CLASS__, __FUNCTION__, 'CLib::GetClientIP', strcasecmp( $sExpect, $sClientIP )
+			);
 		}
 
 		//	...
@@ -74,13 +75,92 @@ class test extends PHPUnit_Framework_TestCase
 			//	...
 			$_SERVER[ $sKey ] = $sValue;
 		}
-		unset( $_SERVER['HTTP_VDATA_FORWARDED_FOR'] );
+		unset( $_SERVER[ 'HTTP_VDATA_FORWARDED_FOR' ] );
 
 		//	...
-		$sClientIP	= delib\CLib::GetClientIP( false, true );
+		$sClientIP	= CLib::GetClientIP( false, true );
 		echo "\r\n+ Play With Proxy=true\r\n";
-		print_r( $_SERVER );
 		echo "\tRESULT:\t" . $sClientIP . "\r\n";
-		$this->assertTrue( 0 == strcasecmp( '45.34.23.101', $sClientIP ) );
+
+		//	...
+		new CAssertResult
+		(
+			__CLASS__,
+			__FUNCTION__,
+			'CLib::GetClientIP',
+			strcasecmp( '45.34.23.101', $sClientIP )
+		);
 	}
+	
+	public function testIsValidMobile()
+	{
+		echo( __FUNCTION__ . "\r\n" );
+
+		//
+		//	static function IsValidMobile( $sStr, $bTrim = false )
+		//
+		$arrVarList	=
+		[
+			[ true,	false,	'13011070903' ],
+			[ true,	false,	'13111070903' ],
+			[ true,	false,	'13211070903' ],
+			[ true,	false,	'13311070903' ],
+			[ true,	false,	'13411070903' ],
+			[ true,	false,	'13511070903' ],
+			[ true,	false,	'13611070903' ],
+			[ true,	false,	'13711070903' ],
+			[ true,	false,	'13811070903' ],
+			[ true,	false,	'13911070903' ],
+
+			[ true,	true,	' 13011070903 ' ],
+			[ true,	true,	' 13111070903 ' ],
+			[ true,	true,	' 13211070903 ' ],
+			[ true,	true,	' 13311070903 ' ],
+			[ true,	true,	' 13411070903 ' ],
+			[ true,	true,	' 13511070903 ' ],
+			[ true,	true,	' 13611070903 ' ],
+			[ true,	true,	' 13711070903 ' ],
+			[ true,	true,	' 13811070903 ' ],
+			[ true,	true,	' 13911070903 ' ],
+
+			[ false, false,	' 13911070903 ' ],
+
+			[ false, true,	'13911070903' ],
+			[ false, true,	'139110709' ],
+			[ false, true,	'13911070' ],
+			[ false, true,	'1391107' ],
+			[ false, true,	'139110' ],
+			[ false, true,	'13911' ],
+			[ false, true,	'1391' ],
+			[ false, true,	'139' ],
+			[ false, true,	'13' ],
+			[ false, true,	'1' ],
+			[ false, true,	'' ],
+			[ false, true,	null ],
+			[ false, true,	[] ],
+		];
+
+		foreach ( $arrVarList as $arrData )
+		{
+			$bExpect	= $arrData[ 0 ];
+			$bTrim		= $arrData[ 1 ];
+			$sValue		= $arrData[ 2 ];
+
+			$bValid		= CLib::IsValidMobile( $sValue, $bTrim );
+
+			//	...
+			new CAssertResult
+			(
+				__CLASS__,
+				__FUNCTION__,
+				'CLib::IsValidMobile',
+				( $bValid == $bExpect ? CConst::ERROR_SUCCESS : CConst::ERROR_FAILED )
+			);
+		}
+		
+	}
+	
+	
+	
+	
 }

--- a/tests/testCLib.php
+++ b/tests/testCLib.php
@@ -15,23 +15,17 @@ class testCLib extends \PHPUnit\Framework\TestCase
 	{
 		$arrVarList	=
 		[
-			[ true,	true,	'HTTP_VDATA_FORWARDED_FOR', '106.39.200.1,106.39.200.2', '106.39.200.1' ],
-			[ true,	false,	'HTTP_VDATA_FORWARDED_FOR', '106.39.200.1,106.39.200.2', '' ],
-			[ false, true,	'HTTP_VDATA_FORWARDED_FOR', '106.39.200.1,106.39.200.2', '106.39.200.1' ],
-			[ false, false,	'HTTP_VDATA_FORWARDED_FOR', '106.39.200.1,106.39.200.2', '' ],
+			[ true,	 true,	'REMOTE_ADDR',	'106.39.200.3',	'106.39.200.3' ],
+			[ true,	 false,	'REMOTE_ADDR',	'106.39.200.3',	'106.39.200.3' ],
+			[ false, true,	'REMOTE_ADDR',	'106.39.200.3',	'106.39.200.3' ],
+			[ false, false,	'REMOTE_ADDR',	'106.39.200.3',	'106.39.200.3' ],
+			[ false, false,	'REMOTE_ADDR',	'192.168.0.1',	'192.168.0.1' ],
+			[ true, false,	'REMOTE_ADDR',	'192.168.0.1',	'' ],
+			[ true, false,	'REMOTE_ADDR',	'',		'' ],
+			[ true, false,	'REMOTE_ADDR',	null,		'' ],
 
-			[ true,	true,	'REMOTE_ADDR', '106.39.200.3', '106.39.200.3' ],
-			[ true,	false,	'REMOTE_ADDR', '106.39.200.3', '106.39.200.3' ],
-			[ false, true,	'REMOTE_ADDR', '106.39.200.3', '106.39.200.3' ],
-			[ false, false,	'REMOTE_ADDR', '106.39.200.3', '106.39.200.3' ],
-
-			[ true,	true,	'HTTP_X_TRUE_IP', '45.34.23.101, 115.238.232.96', '45.34.23.101' ],
-			[ true,	false,	'HTTP_X_TRUE_IP', '45.34.23.101, 115.238.232.96', '45.34.23.101' ],
-			[ false, true,	'HTTP_X_TRUE_IP', '45.34.23.101, 115.238.232.96', '45.34.23.101' ],
-			[ false, false,	'HTTP_X_TRUE_IP', '45.34.23.101, 115.238.232.96', '45.34.23.101' ],
-
-			[ true,	true,	'HTTP_X_FORWARDED_FOR', '106.39.200.5,106.39.200.6', '106.39.200.5' ],
-			[ true,	false,	'HTTP_X_FORWARDED_FOR', '106.39.200.5,106.39.200.6', '' ],
+			[ true,	 true,	'HTTP_X_FORWARDED_FOR', '106.39.200.5,106.39.200.6', '106.39.200.5' ],
+			[ true,	 false,	'HTTP_X_FORWARDED_FOR', '106.39.200.5,106.39.200.6', '' ],
 			[ false, true,	'HTTP_X_FORWARDED_FOR', '106.39.200.5,106.39.200.6', '106.39.200.5' ],
 			[ false, false,	'HTTP_X_FORWARDED_FOR', '106.39.200.5,106.39.200.6', '' ],
 		];
@@ -49,47 +43,23 @@ class testCLib extends \PHPUnit\Framework\TestCase
 				$sKey	=> $sValue,
 			];
 
-			echo "\r\n";
-			echo "+ KEY:    " . $sKey . "\r\n  VALUE:  " . $sValue . "\r\n";
-
-			echo "  PARAM:  MustBePublic=" . ( $bMustBePublic ? "true" : "false" ) . ", ";
-			echo "PlayWithProxy=" . ( $bPlayWithProxy ? "true" : "false" ) . "\r\n";
 			$sClientIP	= CLib::GetClientIP( $bMustBePublic, $bPlayWithProxy );
-			echo "  GOT IP: \"" . $sClientIP . "\"\r\n  EXPECT: \"" . $sExpect . "\"\r\n";
+			$sDumpString	= "" .
+			"+ KEY:    " . $sKey . "\r\n  VALUE:  " . $sValue . "\r\n" .
+			"  PARAM:  MustBePublic=" . ( $bMustBePublic ? "true" : "false" ) . ", " .
+			"PlayWithProxy=" . ( $bPlayWithProxy ? "true" : "false" ) . "\r\n" .
+			"  GOT IP: \"" . $sClientIP . "\"\r\n  EXPECT: \"" . $sExpect . "\"\r\n";
 
 			//	...
 			new CAssertResult
 			(
-				__CLASS__, __FUNCTION__, 'CLib::GetClientIP', strcasecmp( $sExpect, $sClientIP )
+				__CLASS__,
+				__FUNCTION__,
+				'CLib::GetClientIP',
+				strcasecmp( $sExpect, $sClientIP ),
+				$sDumpString
 			);
 		}
-
-		//	...
-		$_SERVER	= [];
-
-		foreach ( $arrVarList as $arrData )
-		{
-			$sKey		= $arrData[ 2 ];
-			$sValue		= $arrData[ 3 ];
-
-			//	...
-			$_SERVER[ $sKey ] = $sValue;
-		}
-		unset( $_SERVER[ 'HTTP_VDATA_FORWARDED_FOR' ] );
-
-		//	...
-		$sClientIP	= CLib::GetClientIP( false, true );
-		echo "\r\n+ Play With Proxy=true\r\n";
-		echo "\tRESULT:\t" . $sClientIP . "\r\n";
-
-		//	...
-		new CAssertResult
-		(
-			__CLASS__,
-			__FUNCTION__,
-			'CLib::GetClientIP',
-			strcasecmp( '45.34.23.101', $sClientIP )
-		);
 	}
 	
 	public function testIsValidMobile()
@@ -101,43 +71,45 @@ class testCLib extends \PHPUnit\Framework\TestCase
 		//
 		$arrVarList	=
 		[
-			[ true,	false,	'13011070903' ],
-			[ true,	false,	'13111070903' ],
-			[ true,	false,	'13211070903' ],
-			[ true,	false,	'13311070903' ],
-			[ true,	false,	'13411070903' ],
-			[ true,	false,	'13511070903' ],
-			[ true,	false,	'13611070903' ],
-			[ true,	false,	'13711070903' ],
-			[ true,	false,	'13811070903' ],
-			[ true,	false,	'13911070903' ],
+			[ true,		false,	'13011070903' ],
+			[ true,		false,	'13111070903' ],
+			[ true,		false,	'13211070903' ],
+			[ true,		false,	'13311070903' ],
+			[ true,		false,	'13411070903' ],
+			[ true,		false,	'13511070903' ],
+			[ true,		false,	'13611070903' ],
+			[ true,		false,	'13711070903' ],
+			[ true,		false,	'13811070903' ],
+			[ true,		false,	'13911070903' ],
 
-			[ true,	true,	' 13011070903 ' ],
-			[ true,	true,	' 13111070903 ' ],
-			[ true,	true,	' 13211070903 ' ],
-			[ true,	true,	' 13311070903 ' ],
-			[ true,	true,	' 13411070903 ' ],
-			[ true,	true,	' 13511070903 ' ],
-			[ true,	true,	' 13611070903 ' ],
-			[ true,	true,	' 13711070903 ' ],
-			[ true,	true,	' 13811070903 ' ],
-			[ true,	true,	' 13911070903 ' ],
+			[ false,	false,	'139-1070903' ],
 
-			[ false, false,	' 13911070903 ' ],
+			[ true,		true,	' 13011070903 ' ],
+			[ true,		true,	' 13111070903 ' ],
+			[ true,		true,	' 13211070903 ' ],
+			[ true,		true,	' 13311070903 ' ],
+			[ true,		true,	' 13411070903 ' ],
+			[ true,		true,	' 13511070903 ' ],
+			[ true,		true,	' 13611070903 ' ],
+			[ true,		true,	' 13711070903 ' ],
+			[ true,		true,	' 13811070903 ' ],
+			[ true,		true,	' 13911070903 ' ],
 
-			[ false, true,	'13911070903' ],
-			[ false, true,	'139110709' ],
-			[ false, true,	'13911070' ],
-			[ false, true,	'1391107' ],
-			[ false, true,	'139110' ],
-			[ false, true,	'13911' ],
-			[ false, true,	'1391' ],
-			[ false, true,	'139' ],
-			[ false, true,	'13' ],
-			[ false, true,	'1' ],
-			[ false, true,	'' ],
-			[ false, true,	null ],
-			[ false, true,	[] ],
+			[ false,	false,	' 13911070903 ' ],
+
+			[ true,		true,	'13911070903' ],
+			[ false,	true,	'139110709' ],
+			[ false,	true,	'13911070' ],
+			[ false,	true,	'1391107' ],
+			[ false,	true,	'139110' ],
+			[ false,	true,	'13911' ],
+			[ false,	true,	'1391' ],
+			[ false,	true,	'139' ],
+			[ false,	true,	'13' ],
+			[ false,	true,	'1' ],
+			[ false,	true,	'' ],
+			[ false,	true,	null ],
+			[ false,	true,	[] ],
 		];
 
 		foreach ( $arrVarList as $arrData )
@@ -154,7 +126,8 @@ class testCLib extends \PHPUnit\Framework\TestCase
 				__CLASS__,
 				__FUNCTION__,
 				'CLib::IsValidMobile',
-				( $bValid == $bExpect ? CConst::ERROR_SUCCESS : CConst::ERROR_FAILED )
+				( $bValid == $bExpect ? CConst::ERROR_SUCCESS : CConst::ERROR_FAILED ),
+				$arrData
 			);
 		}
 		


### PR DESCRIPTION
1, Added 16*, 19* numbers for CLib::IsValidMobile( $sStr, $bTrim = false )
2, Upgrade CLib::GetClientIP, remove supports for key HTTP_VDATA_FORWARDED_FOR and HTTP_X_TRUE_IP
